### PR TITLE
Add US EPA AQI calculation

### DIFF
--- a/aqi.go
+++ b/aqi.go
@@ -41,13 +41,13 @@ var pm25Breakpoints = []PM25Breakpoint{
 
 // PM10 breakpoints based on EPA standards
 var pm10Breakpoints = []PM10Breakpoint{
-	{0, 54, 0, 50},        // Good
-	{55, 154, 51, 100},    // Moderate
-	{155, 254, 101, 150},  // Unhealthy for Sensitive Groups
-	{255, 354, 151, 200},  // Unhealthy
-	{355, 424, 201, 300},  // Very Unhealthy
-	{425, 504, 301, 400},  // Hazardous
-	{505, 604, 401, 500},  // Hazardous
+	{0, 54, 0, 50},       // Good
+	{55, 154, 51, 100},   // Moderate
+	{155, 254, 101, 150}, // Unhealthy for Sensitive Groups
+	{255, 354, 151, 200}, // Unhealthy
+	{355, 424, 201, 300}, // Very Unhealthy
+	{425, 504, 301, 400}, // Hazardous
+	{505, 604, 401, 500}, // Hazardous
 }
 
 // AQI categories
@@ -119,7 +119,7 @@ func calculateAQI(concentration float32, breakpoints interface{}) int {
 
 	// AQI equation: I = ((IHi - ILo) / (BPHi - BPLo)) * (Cp - BPLo) + ILo
 	aqi := ((float32(aqiHi-aqiLo) / (concHi - concLo)) * (concentration - concLo)) + float32(aqiLo)
-	
+
 	// Round to nearest integer
 	return int(math.Round(float64(aqi)))
 }
@@ -127,10 +127,10 @@ func calculateAQI(concentration float32, breakpoints interface{}) int {
 // CalculatePM25AQI calculates the AQI from PM2.5 concentration (μg/m³)
 func CalculatePM25AQI(concentration float32) AQIResult {
 	aqi := calculateAQI(concentration, pm25Breakpoints)
-	
+
 	category := ""
 	color := ""
-	
+
 	// Determine category and color
 	for _, info := range aqiCategories {
 		if aqi <= info.Threshold {
@@ -139,19 +139,19 @@ func CalculatePM25AQI(concentration float32) AQIResult {
 			break
 		}
 	}
-	
+
 	// If AQI > 500, it's still Hazardous
 	if aqi > 500 {
-		category = "Hazardous"
-		color = "Maroon"
+		category = aqiCategories[len(aqiCategories)-1].Category
+		color = aqiCategories[len(aqiCategories)-1].Color
 	}
-	
+
 	// Sensitive groups for PM2.5
 	sensitiveGroup := ""
 	if aqi > 100 {
 		sensitiveGroup = "People with heart or lung disease, older adults, children, and people of lower socioeconomic status"
 	}
-	
+
 	return AQIResult{
 		AQI:            aqi,
 		Category:       category,
@@ -163,10 +163,10 @@ func CalculatePM25AQI(concentration float32) AQIResult {
 // CalculatePM10AQI calculates the AQI from PM10 concentration (μg/m³)
 func CalculatePM10AQI(concentration float32) AQIResult {
 	aqi := calculateAQI(concentration, pm10Breakpoints)
-	
+
 	category := ""
 	color := ""
-	
+
 	// Determine category and color
 	for _, info := range aqiCategories {
 		if aqi <= info.Threshold {
@@ -175,19 +175,19 @@ func CalculatePM10AQI(concentration float32) AQIResult {
 			break
 		}
 	}
-	
+
 	// If AQI > 500, it's still Hazardous
 	if aqi > 500 {
 		category = "Hazardous"
 		color = "Maroon"
 	}
-	
+
 	// Sensitive groups for PM10
 	sensitiveGroup := ""
 	if aqi > 100 {
 		sensitiveGroup = "People with heart or lung disease, older adults, children, and people of lower socioeconomic status"
 	}
-	
+
 	return AQIResult{
 		AQI:            aqi,
 		Category:       category,
@@ -200,7 +200,7 @@ func CalculatePM10AQI(concentration float32) AQIResult {
 func CalculateOverallAQI(pm25 float32, pm10 float32) AQIResult {
 	pm25Result := CalculatePM25AQI(pm25)
 	pm10Result := CalculatePM10AQI(pm10)
-	
+
 	// Return the result with the higher AQI
 	if pm25Result.AQI >= pm10Result.AQI {
 		return pm25Result

--- a/aqi.go
+++ b/aqi.go
@@ -56,12 +56,12 @@ var aqiCategories = []struct {
 	Category  string
 	Color     string
 }{
-	{50, "Good", "Green"},
-	{100, "Moderate", "Yellow"},
-	{150, "Unhealthy for Sensitive Groups", "Orange"},
-	{200, "Unhealthy", "Red"},
-	{300, "Very Unhealthy", "Purple"},
-	{500, "Hazardous", "Maroon"},
+	{50, "Good", "rgb(0,228,0)"},
+	{100, "Moderate", "rgb(255,255,0)"},
+	{150, "Unhealthy for Sensitive Groups", "rgb(255,126,0)"},
+	{200, "Unhealthy", "rgb(255,0,0)"},
+	{300, "Very Unhealthy", "rgb(143,63,151)"},
+	{500, "Hazardous", "rgb(126,0,35)"},
 }
 
 // CalculateAQI calculates the AQI value from a concentration using the provided breakpoints
@@ -179,7 +179,7 @@ func CalculatePM10AQI(concentration float32) AQIResult {
 	// If AQI > 500, it's still Hazardous
 	if aqi > 500 {
 		category = "Hazardous"
-		color = "Maroon"
+		color = "rgb(126,0,35)"
 	}
 
 	// Sensitive groups for PM10

--- a/aqi.go
+++ b/aqi.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"math"
+)
+
+// AQIResult contains the calculated AQI value and associated information
+type AQIResult struct {
+	AQI            int
+	Category       string
+	Color          string
+	SensitiveGroup string
+}
+
+// PM25Breakpoint represents a breakpoint for PM2.5 AQI calculation
+type PM25Breakpoint struct {
+	ConcLo float32
+	ConcHi float32
+	AQILo  int
+	AQIHi  int
+}
+
+// PM10Breakpoint represents a breakpoint for PM10 AQI calculation
+type PM10Breakpoint struct {
+	ConcLo float32
+	ConcHi float32
+	AQILo  int
+	AQIHi  int
+}
+
+// PM2.5 breakpoints based on EPA standards
+var pm25Breakpoints = []PM25Breakpoint{
+	{0.0, 12.0, 0, 50},       // Good
+	{12.1, 35.4, 51, 100},    // Moderate
+	{35.5, 55.4, 101, 150},   // Unhealthy for Sensitive Groups
+	{55.5, 150.4, 151, 200},  // Unhealthy
+	{150.5, 250.4, 201, 300}, // Very Unhealthy
+	{250.5, 350.4, 301, 400}, // Hazardous
+	{350.5, 500.4, 401, 500}, // Hazardous
+}
+
+// PM10 breakpoints based on EPA standards
+var pm10Breakpoints = []PM10Breakpoint{
+	{0, 54, 0, 50},        // Good
+	{55, 154, 51, 100},    // Moderate
+	{155, 254, 101, 150},  // Unhealthy for Sensitive Groups
+	{255, 354, 151, 200},  // Unhealthy
+	{355, 424, 201, 300},  // Very Unhealthy
+	{425, 504, 301, 400},  // Hazardous
+	{505, 604, 401, 500},  // Hazardous
+}
+
+// AQI categories
+var aqiCategories = []struct {
+	Threshold int
+	Category  string
+	Color     string
+}{
+	{50, "Good", "Green"},
+	{100, "Moderate", "Yellow"},
+	{150, "Unhealthy for Sensitive Groups", "Orange"},
+	{200, "Unhealthy", "Red"},
+	{300, "Very Unhealthy", "Purple"},
+	{500, "Hazardous", "Maroon"},
+}
+
+// CalculateAQI calculates the AQI value from a concentration using the provided breakpoints
+func calculateAQI(concentration float32, breakpoints interface{}) int {
+	var concLo, concHi float32
+	var aqiLo, aqiHi int
+	found := false
+
+	switch bp := breakpoints.(type) {
+	case []PM25Breakpoint:
+		// Truncate PM2.5 to 1 decimal place
+		concentration = float32(math.Floor(float64(concentration)*10) / 10)
+		for _, b := range bp {
+			if concentration >= b.ConcLo && concentration <= b.ConcHi {
+				concLo = b.ConcLo
+				concHi = b.ConcHi
+				aqiLo = b.AQILo
+				aqiHi = b.AQIHi
+				found = true
+				break
+			}
+		}
+	case []PM10Breakpoint:
+		// Truncate PM10 to integer
+		concentration = float32(int(concentration))
+		for _, b := range bp {
+			if concentration >= b.ConcLo && concentration <= b.ConcHi {
+				concLo = b.ConcLo
+				concHi = b.ConcHi
+				aqiLo = b.AQILo
+				aqiHi = b.AQIHi
+				found = true
+				break
+			}
+		}
+	}
+
+	if !found {
+		// Beyond AQI - use highest breakpoint and linear extrapolation
+		switch bp := breakpoints.(type) {
+		case []PM25Breakpoint:
+			last := bp[len(bp)-1]
+			concLo = last.ConcLo
+			concHi = last.ConcHi
+			aqiLo = last.AQILo
+			aqiHi = last.AQIHi
+		case []PM10Breakpoint:
+			last := bp[len(bp)-1]
+			concLo = last.ConcLo
+			concHi = last.ConcHi
+			aqiLo = last.AQILo
+			aqiHi = last.AQIHi
+		}
+	}
+
+	// AQI equation: I = ((IHi - ILo) / (BPHi - BPLo)) * (Cp - BPLo) + ILo
+	aqi := ((float32(aqiHi-aqiLo) / (concHi - concLo)) * (concentration - concLo)) + float32(aqiLo)
+	
+	// Round to nearest integer
+	return int(math.Round(float64(aqi)))
+}
+
+// CalculatePM25AQI calculates the AQI from PM2.5 concentration (μg/m³)
+func CalculatePM25AQI(concentration float32) AQIResult {
+	aqi := calculateAQI(concentration, pm25Breakpoints)
+	
+	category := ""
+	color := ""
+	
+	// Determine category and color
+	for _, info := range aqiCategories {
+		if aqi <= info.Threshold {
+			category = info.Category
+			color = info.Color
+			break
+		}
+	}
+	
+	// If AQI > 500, it's still Hazardous
+	if aqi > 500 {
+		category = "Hazardous"
+		color = "Maroon"
+	}
+	
+	// Sensitive groups for PM2.5
+	sensitiveGroup := ""
+	if aqi > 100 {
+		sensitiveGroup = "People with heart or lung disease, older adults, children, and people of lower socioeconomic status"
+	}
+	
+	return AQIResult{
+		AQI:            aqi,
+		Category:       category,
+		Color:          color,
+		SensitiveGroup: sensitiveGroup,
+	}
+}
+
+// CalculatePM10AQI calculates the AQI from PM10 concentration (μg/m³)
+func CalculatePM10AQI(concentration float32) AQIResult {
+	aqi := calculateAQI(concentration, pm10Breakpoints)
+	
+	category := ""
+	color := ""
+	
+	// Determine category and color
+	for _, info := range aqiCategories {
+		if aqi <= info.Threshold {
+			category = info.Category
+			color = info.Color
+			break
+		}
+	}
+	
+	// If AQI > 500, it's still Hazardous
+	if aqi > 500 {
+		category = "Hazardous"
+		color = "Maroon"
+	}
+	
+	// Sensitive groups for PM10
+	sensitiveGroup := ""
+	if aqi > 100 {
+		sensitiveGroup = "People with heart or lung disease, older adults, children, and people of lower socioeconomic status"
+	}
+	
+	return AQIResult{
+		AQI:            aqi,
+		Category:       category,
+		Color:          color,
+		SensitiveGroup: sensitiveGroup,
+	}
+}
+
+// CalculateOverallAQI calculates the overall AQI (highest of PM2.5 and PM10)
+func CalculateOverallAQI(pm25 float32, pm10 float32) AQIResult {
+	pm25Result := CalculatePM25AQI(pm25)
+	pm10Result := CalculatePM10AQI(pm10)
+	
+	// Return the result with the higher AQI
+	if pm25Result.AQI >= pm10Result.AQI {
+		return pm25Result
+	}
+	return pm10Result
+}

--- a/aqi_test.go
+++ b/aqi_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCalculatePM25AQI(t *testing.T) {
+	tests := []struct {
+		name          string
+		concentration float32
+		expectedAQI   int
+		expectedCat   string
+		expectedColor string
+	}{
+		{"Good - Low", 5.0, 21, "Good", "Green"},
+		{"Good - High", 12.0, 50, "Good", "Green"},
+		{"Moderate - Low", 12.1, 51, "Moderate", "Yellow"},
+		{"Moderate - Mid", 23.75, 75, "Moderate", "Yellow"},
+		{"Moderate - High", 35.4, 100, "Moderate", "Yellow"},
+		{"USG - Low", 35.5, 101, "Unhealthy for Sensitive Groups", "Orange"},
+		{"USG - High", 55.4, 150, "Unhealthy for Sensitive Groups", "Orange"},
+		{"Unhealthy - Low", 55.5, 151, "Unhealthy", "Red"},
+		{"Unhealthy - Mid", 100.0, 174, "Unhealthy", "Red"},
+		{"Unhealthy - High", 150.4, 200, "Unhealthy", "Red"},
+		{"Very Unhealthy - Low", 150.5, 201, "Very Unhealthy", "Purple"},
+		{"Very Unhealthy - High", 250.4, 300, "Very Unhealthy", "Purple"},
+		{"Hazardous - Low", 250.5, 301, "Hazardous", "Maroon"},
+		{"Hazardous - High", 500.4, 500, "Hazardous", "Maroon"},
+		{"Beyond AQI", 600.0, 566, "Hazardous", "Maroon"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculatePM25AQI(tt.concentration)
+			if result.AQI != tt.expectedAQI {
+				t.Errorf("CalculatePM25AQI(%f) AQI = %d, want %d", tt.concentration, result.AQI, tt.expectedAQI)
+			}
+			if result.Category != tt.expectedCat {
+				t.Errorf("CalculatePM25AQI(%f) Category = %s, want %s", tt.concentration, result.Category, tt.expectedCat)
+			}
+			if result.Color != tt.expectedColor {
+				t.Errorf("CalculatePM25AQI(%f) Color = %s, want %s", tt.concentration, result.Color, tt.expectedColor)
+			}
+		})
+	}
+}
+
+func TestCalculatePM10AQI(t *testing.T) {
+	tests := []struct {
+		name          string
+		concentration float32
+		expectedAQI   int
+		expectedCat   string
+		expectedColor string
+	}{
+		{"Good - Low", 25.0, 23, "Good", "Green"},
+		{"Good - High", 54.0, 50, "Good", "Green"},
+		{"Moderate - Low", 55.0, 51, "Moderate", "Yellow"},
+		{"Moderate - Mid", 100.0, 73, "Moderate", "Yellow"},
+		{"Moderate - High", 154.0, 100, "Moderate", "Yellow"},
+		{"USG - Low", 155.0, 101, "Unhealthy for Sensitive Groups", "Orange"},
+		{"USG - High", 254.0, 150, "Unhealthy for Sensitive Groups", "Orange"},
+		{"Unhealthy - Low", 255.0, 151, "Unhealthy", "Red"},
+		{"Unhealthy - High", 354.0, 200, "Unhealthy", "Red"},
+		{"Very Unhealthy - Low", 355.0, 201, "Very Unhealthy", "Purple"},
+		{"Hazardous", 425.0, 301, "Hazardous", "Maroon"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculatePM10AQI(tt.concentration)
+			if result.AQI != tt.expectedAQI {
+				t.Errorf("CalculatePM10AQI(%f) AQI = %d, want %d", tt.concentration, result.AQI, tt.expectedAQI)
+			}
+			if result.Category != tt.expectedCat {
+				t.Errorf("CalculatePM10AQI(%f) Category = %s, want %s", tt.concentration, result.Category, tt.expectedCat)
+			}
+			if result.Color != tt.expectedColor {
+				t.Errorf("CalculatePM10AQI(%f) Color = %s, want %s", tt.concentration, result.Color, tt.expectedColor)
+			}
+		})
+	}
+}
+
+func TestCalculateOverallAQI(t *testing.T) {
+	tests := []struct {
+		name        string
+		pm25        float32
+		pm10        float32
+		expectedAQI int
+		expectedCat string
+	}{
+		{"Both Good", 10.0, 40.0, 42, "Good"},
+		{"PM2.5 Higher", 35.5, 100.0, 101, "Unhealthy for Sensitive Groups"},
+		{"PM10 Higher", 20.0, 200.0, 123, "Unhealthy for Sensitive Groups"},
+		{"Both Unhealthy", 100.0, 300.0, 174, "Unhealthy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateOverallAQI(tt.pm25, tt.pm10)
+			if result.AQI != tt.expectedAQI {
+				t.Errorf("CalculateOverallAQI(%f, %f) AQI = %d, want %d", tt.pm25, tt.pm10, result.AQI, tt.expectedAQI)
+			}
+			if result.Category != tt.expectedCat {
+				t.Errorf("CalculateOverallAQI(%f, %f) Category = %s, want %s", tt.pm25, tt.pm10, result.Category, tt.expectedCat)
+			}
+		})
+	}
+}
+
+// Example function to demonstrate usage
+func ExampleCalculatePM25AQI() {
+	result := CalculatePM25AQI(35.5)
+	fmt.Printf("PM2.5 concentration: 35.5 μg/m³\n")
+	fmt.Printf("AQI: %d\n", result.AQI)
+	fmt.Printf("Category: %s\n", result.Category)
+	fmt.Printf("Color: %s\n", result.Color)
+	// Output:
+	// PM2.5 concentration: 35.5 μg/m³
+	// AQI: 101
+	// Category: Unhealthy for Sensitive Groups
+	// Color: Orange
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,43 @@
+# Example configuration file for purpleair2mqtt
+# Copy this file to config.toml and modify as needed
+
+[purpleair]
+    # URL of your PurpleAir sensor's JSON endpoint
+    url = "http://192.168.1.24/json"
+    # How often to poll the sensor (in seconds)
+    poll_rate = 120
+    # HTTP request timeout (in seconds)
+    timeout = 15
+
+[mqtt]
+    # MQTT broker hostname
+    broker_host = "localhost"
+    # MQTT broker port
+    broker_port = 1883
+    # MQTT client ID
+    client_id = "purpleair2mqtt"
+    # MQTT topic prefix (default: "purpleair")
+    topic_prefix = "airquality"
+    # MQTT topic name (if empty, uses sensor's Geo field)
+    topic = ""
+    # MQTT authentication (optional)
+    # broker_username = "username"
+    # broker_password = "password"
+
+# Home Assistant integration (optional)
+# [hass]
+#     discovery = true
+#     discovery_prefix = "homeassistant"
+#     device_model = "pa-sd-ii"
+#     device_name = "pa-sd-ii"
+#     object_id = "pa-sd-ii"
+
+# InfluxDB integration (optional)
+# [influx]
+#     hostname = "localhost"
+#     port = 8086
+#     database = "purpleair"
+#     username = "your_username"
+#     password = "your_password"
+#     measurement_name = "purpleair_monitor"
+#     status_measurement_name = "purpleair_status"

--- a/purpleair2mqtt.go
+++ b/purpleair2mqtt.go
@@ -87,6 +87,13 @@ type purpleAirMonitor struct {
 	Key2ResponseDate int     `json:"key2_response_date"`
 	Key2Count        int     `json:"key2_count"`
 	TsSLatency       int     `json:"ts_s_latency"`
+	
+	// US EPA AQI fields
+	EPAAQI           int     // US EPA AQI value (highest of PM2.5 and PM10)
+	EPAPM25AQI       int     // US EPA PM2.5 AQI
+	EPAPM10AQI       int     // US EPA PM10 AQI
+	EPAAQICategory   string  // US EPA AQI category
+	EPAAQIColor      string  // US EPA AQI color
 }
 
 type purpleAirStatus struct {
@@ -180,6 +187,13 @@ type purpleAirStatus struct {
 	Status8       int    `json:"status_8"`
 	Status9       int    `json:"status_9"`
 	SSID          string `json:"ssid"`
+	
+	// US EPA AQI fields for overall sensor
+	EPAAQI           int     // US EPA AQI value (highest of PM2.5 and PM10)
+	EPAPM25AQI       int     // US EPA PM2.5 AQI
+	EPAPM10AQI       int     // US EPA PM10 AQI
+	EPAAQICategory   string  // US EPA AQI category
+	EPAAQIColor      string  // US EPA AQI color
 }
 
 // set up a global logger...
@@ -259,6 +273,7 @@ func main() {
 			panic(err)
 		}
 		normalizePaStatus(pastatus)
+		calculateEPAAQI(pastatus)
 
 		// if we don't set the specific topic, then we can grab and set the topic from the Geo field
 		// this is useful if you're polling from multiple different sensors and aggregating them and
@@ -271,6 +286,8 @@ func main() {
 		logger.Infof("Sensor 1 AQI: %d", pastatus.PM25Aqi)
 		logger.Infof("Sensor 2 Color: %s", pastatus.PM25AqiColorB)
 		logger.Infof("Sensor 2 AQI: %d", pastatus.B.PM25Aqi)
+		logger.Infof("US EPA AQI: %d (%s - %s)", pastatus.EPAAQI, pastatus.EPAAQICategory, pastatus.EPAAQIColor)
+		logger.Infof("US EPA PM2.5 AQI: %d, PM10 AQI: %d", pastatus.EPAPM25AQI, pastatus.EPAPM10AQI)
 
 		if config.Influx != (tomlConfigInflux{}) {
 			write_influx(pastatus, &pastatus.A, &pastatus.B)
@@ -343,6 +360,53 @@ func normalizePaStatus(pastatus *purpleAirStatus) *purpleAirStatus {
 	return pastatus
 }
 
+func calculateEPAAQI(pastatus *purpleAirStatus) {
+	// Calculate EPA AQI for sensor A
+	if pastatus.A.PM25Cf1 > 0 || pastatus.A.PM100Cf1 > 0 {
+		aqiResult := CalculateOverallAQI(pastatus.A.PM25Cf1, pastatus.A.PM100Cf1)
+		pastatus.A.EPAAQI = aqiResult.AQI
+		pastatus.A.EPAAQICategory = aqiResult.Category
+		pastatus.A.EPAAQIColor = aqiResult.Color
+		
+		// Also calculate individual PM2.5 and PM10 AQI values
+		pm25Result := CalculatePM25AQI(pastatus.A.PM25Cf1)
+		pastatus.A.EPAPM25AQI = pm25Result.AQI
+		
+		pm10Result := CalculatePM10AQI(pastatus.A.PM100Cf1)
+		pastatus.A.EPAPM10AQI = pm10Result.AQI
+	}
+	
+	// Calculate EPA AQI for sensor B
+	if pastatus.B.PM25Cf1 > 0 || pastatus.B.PM100Cf1 > 0 {
+		aqiResult := CalculateOverallAQI(pastatus.B.PM25Cf1, pastatus.B.PM100Cf1)
+		pastatus.B.EPAAQI = aqiResult.AQI
+		pastatus.B.EPAAQICategory = aqiResult.Category
+		pastatus.B.EPAAQIColor = aqiResult.Color
+		
+		// Also calculate individual PM2.5 and PM10 AQI values
+		pm25Result := CalculatePM25AQI(pastatus.B.PM25Cf1)
+		pastatus.B.EPAPM25AQI = pm25Result.AQI
+		
+		pm10Result := CalculatePM10AQI(pastatus.B.PM100Cf1)
+		pastatus.B.EPAPM10AQI = pm10Result.AQI
+	}
+	
+	// Calculate overall EPA AQI (average of both sensors)
+	if pastatus.PM25Cf1 > 0 || pastatus.PM100Cf1 > 0 {
+		aqiResult := CalculateOverallAQI(pastatus.PM25Cf1, pastatus.PM100Cf1)
+		pastatus.EPAAQI = aqiResult.AQI
+		pastatus.EPAAQICategory = aqiResult.Category
+		pastatus.EPAAQIColor = aqiResult.Color
+		
+		// Also calculate individual PM2.5 and PM10 AQI values
+		pm25Result := CalculatePM25AQI(pastatus.PM25Cf1)
+		pastatus.EPAPM25AQI = pm25Result.AQI
+		
+		pm10Result := CalculatePM10AQI(pastatus.PM100Cf1)
+		pastatus.EPAPM10AQI = pm10Result.AQI
+	}
+}
+
 func getJson(url string, target interface{}, myClient *http.Client) error {
 	return retry.Do(
 		func() error {
@@ -371,6 +435,13 @@ func status_to_point(status *purpleAirStatus) (*influxclient.Point, error) {
 	values["pressure"] = status.Pressure
 	values["dewpoint"] = status.Dewpoint
 	values["rssi"] = status.RSSI
+	
+	// Add US EPA AQI values
+	values["epa_aqi"] = status.EPAAQI
+	values["epa_pm25_aqi"] = status.EPAPM25AQI
+	values["epa_pm10_aqi"] = status.EPAPM10AQI
+	values["epa_aqi_category"] = status.EPAAQICategory
+	values["epa_aqi_color"] = status.EPAAQIColor
 
 	measurementName := "purpleair_status"
 	if config.Influx.StatusMeasurementName != "" {
@@ -405,6 +476,13 @@ func monitor_to_point(monitor *purpleAirMonitor) (*influxclient.Point, error) {
 	values["key2_response_date"] = monitor.Key2ResponseDate
 	values["key2_count"] = monitor.Key2Count
 	values["ts_s_latency"] = monitor.TsSLatency
+	
+	// Add US EPA AQI values
+	values["epa_aqi"] = monitor.EPAAQI
+	values["epa_pm25_aqi"] = monitor.EPAPM25AQI
+	values["epa_pm10_aqi"] = monitor.EPAPM10AQI
+	values["epa_aqi_category"] = monitor.EPAAQICategory
+	values["epa_aqi_color"] = monitor.EPAAQIColor
 
 	measurementName := "purpleair_monitor"
 	if config.Influx.MeasurementName != "" {
@@ -419,7 +497,7 @@ func write_influx(status *purpleAirStatus, monitorA *purpleAirMonitor, monitorB 
 		Addr: fmt.Sprintf("http://%s:%d", config.Influx.Hostname, config.Influx.Port),
 	})
 	if err != nil {
-		logger.Errorf("Error creating InfluxDB Client: ", err.Error())
+		logger.Errorf("Error creating InfluxDB Client: %s", err.Error())
 	}
 	defer c.Close()
 
@@ -474,5 +552,28 @@ func publishMQTT(status *purpleAirStatus) {
 		token := client.Publish(topic, 0, false, fmt.Sprintf("%v", fieldValue))
 		token.Wait()
 	}
+	
+	// Also publish sensor A and B EPA AQI values
+	publishSensorEPAAQI(&status.A, "A")
+	publishSensorEPAAQI(&status.B, "B")
+}
 
+func publishSensorEPAAQI(monitor *purpleAirMonitor, sensor string) {
+	// Publish EPA AQI values for individual sensors
+	baseTopic := fmt.Sprintf("%s/%s/sensor_%s", config.Mqtt.TopicPrefix, config.Mqtt.Topic, sensor)
+	
+	token := client.Publish(fmt.Sprintf("%s/epa_aqi", baseTopic), 0, false, fmt.Sprintf("%d", monitor.EPAAQI))
+	token.Wait()
+	
+	token = client.Publish(fmt.Sprintf("%s/epa_pm25_aqi", baseTopic), 0, false, fmt.Sprintf("%d", monitor.EPAPM25AQI))
+	token.Wait()
+	
+	token = client.Publish(fmt.Sprintf("%s/epa_pm10_aqi", baseTopic), 0, false, fmt.Sprintf("%d", monitor.EPAPM10AQI))
+	token.Wait()
+	
+	token = client.Publish(fmt.Sprintf("%s/epa_aqi_category", baseTopic), 0, false, monitor.EPAAQICategory)
+	token.Wait()
+	
+	token = client.Publish(fmt.Sprintf("%s/epa_aqi_color", baseTopic), 0, false, monitor.EPAAQIColor)
+	token.Wait()
 }


### PR DESCRIPTION
Add US EPA AQI calculation based on PurpleAir sensor data to provide standardized air quality reporting.

This implementation adheres to the official EPA Technical Assistance Document for AQI calculation, providing PM2.5, PM10, and overall AQI values, categories, and colors. These new metrics are integrated into existing logging, InfluxDB, and MQTT publishing mechanisms.