### PR TITLE
Add heartbeat support for health monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ WORKDIR /src/${BIN_NAME}
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
-FROM scratch
+FROM alpine:latest
+RUN apk add --no-cache curl
 ARG BIN_NAME
 ARG BIN_VERSION
 COPY --from=builder /src/${BIN_NAME}/out/${BIN_NAME} /usr/bin/${BIN_NAME}
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-HEALTHCHECK CMD ["/usr/bin/purpleair2mqtt", "-healthcheck"]
+HEALTHCHECK CMD ["curl", "-sf", "http://localhost:6001/"]
 ENTRYPOINT ["/usr/bin/purpleair2mqtt"]
 CMD ["-config", "/config.toml"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk add --no-cache curl
 ARG BIN_NAME
 ARG BIN_VERSION
 COPY --from=builder /src/${BIN_NAME}/out/${BIN_NAME} /usr/bin/${BIN_NAME}
-HEALTHCHECK CMD ["curl", "-sf", "http://localhost:6001/"]
 ENTRYPOINT ["/usr/bin/purpleair2mqtt"]
 CMD ["-config", "/config.toml"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG BIN_NAME
 ARG BIN_VERSION
 COPY --from=builder /src/${BIN_NAME}/out/${BIN_NAME} /usr/bin/${BIN_NAME}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-HEALTHCHECK CMD ["/usr/bin/purpleair2mqtt", "-healthcheck", "-healthcheck-url", "http://localhost:6001"]
+HEALTHCHECK CMD ["/usr/bin/purpleair2mqtt", "-healthcheck"]
 ENTRYPOINT ["/usr/bin/purpleair2mqtt"]
 CMD ["-config", "/config.toml"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ARG BIN_NAME
 ARG BIN_VERSION
 COPY --from=builder /src/${BIN_NAME}/out/${BIN_NAME} /usr/bin/${BIN_NAME}
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+HEALTHCHECK CMD ["/usr/bin/purpleair2mqtt", "-healthcheck", "-healthcheck-url", "http://localhost:6001"]
 ENTRYPOINT ["/usr/bin/purpleair2mqtt"]
 CMD ["-config", "/config.toml"]
 

--- a/README.md
+++ b/README.md
@@ -191,22 +191,17 @@ services:
 
 ### Docker Health Check
 
-If you configure `health_port` in the `[heartbeat]` section of your config file, the Docker image includes a built-in `HEALTHCHECK` using `curl` that queries the health server at `http://localhost:6001`. To use a different port, override the healthcheck in your Docker Compose file:
+If you configure `health_port` in the `[heartbeat]` section of your config file, you can add a Docker health check using `curl` (which is included in the image). Add this to your Docker Compose file:
 
 ```yaml
 healthcheck:
-  test: ["curl", "-sf", "http://localhost:YOUR_PORT/"]
+  test: ["curl", "-sf", "http://localhost:6001/"]
   interval: 60s
   timeout: 5s
   retries: 3
 ```
 
-If you don't configure `health_port`, the built-in `HEALTHCHECK` will report the container as unhealthy. In that case, disable it in your Compose file:
-
-```yaml
-healthcheck:
-  disable: true
-```
+Replace `6001` with your configured `health_port` if different.
 
 ### Building the Container Locally
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ Run `make help` to see all available targets.
 
 - `-config <file>`: Path to the TOML configuration file (required)
 - `-version`: Print version and exit
-- `-healthcheck`: Run a health check against the local health server and exit
-- `-healthcheck-url <url>`: URL for the health check endpoint (default: `http://localhost:6001`)
 
 ## Running with Docker
 
@@ -193,11 +191,11 @@ services:
 
 ### Docker Health Check
 
-If you configure `health_port` in the `[heartbeat]` section of your config file, the Docker image includes a built-in `HEALTHCHECK` that queries the health server at `http://localhost:6001`. To use a different port, override the healthcheck in your Docker Compose file:
+If you configure `health_port` in the `[heartbeat]` section of your config file, the Docker image includes a built-in `HEALTHCHECK` using `curl` that queries the health server at `http://localhost:6001`. To use a different port, override the healthcheck in your Docker Compose file:
 
 ```yaml
 healthcheck:
-  test: ["/usr/bin/purpleair2mqtt", "-healthcheck", "-healthcheck-url", "http://localhost:YOUR_PORT"]
+  test: ["curl", "-sf", "http://localhost:YOUR_PORT/"]
   interval: 60s
   timeout: 5s
   retries: 3

--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ Finally, if you'd like to use the native InfluxDB integration, this section shou
     password = "YOUR_PASSWORD"
 ```
 
+Optionally, you can configure a heartbeat to monitor the health of the application. This works well with [Uptime Kuma](https://github.com/louislam/uptime-kuma)'s push monitors. The heartbeat is sent after each successful poll cycle (i.e. after successfully polling PurpleAir and writing to all configured outputs). If any operation fails, the heartbeat is not sent.
+
+You can configure an outgoing heartbeat URL, a local health check HTTP server, or both:
+
+```toml
+[heartbeat]
+    # URL to GET for heartbeat pings (e.g. Uptime Kuma push URL).
+    # Optional; at least one of url or health_port must be set.
+    url = "https://uptimekuma.example.com:9001/api/push/abcd1234?status=up&msg=OK&ping="
+    # Heartbeat ping interval in seconds (default: poll_rate)
+    interval_s = 120
+    # Liveness threshold in seconds. If no successful poll has occurred within
+    # this period, outgoing heartbeats are paused and the health endpoint
+    # reports unhealthy. (default: poll_rate * 3)
+    threshold_s = 360
+    # Port for the health check HTTP server. A GET to / returns {"ok":true}
+    # with HTTP 200 when healthy, or {"ok":false} with HTTP 503 when unhealthy.
+    # Optional; at least one of url or health_port must be set.
+    health_port = 6001
+```
+
 ## Building the Application
 
 To build for the current platform:
@@ -137,6 +158,8 @@ Run `make help` to see all available targets.
 
 - `-config <file>`: Path to the TOML configuration file (required)
 - `-version`: Print version and exit
+- `-healthcheck`: Run a health check against the local health server and exit
+- `-healthcheck-url <url>`: URL for the health check endpoint (default: `http://localhost:6001`)
 
 ## Running with Docker
 
@@ -166,6 +189,18 @@ services:
     network_mode: host
     volumes:
       - ./config.toml:/config.toml:ro
+```
+
+### Docker Health Check
+
+If you configure `health_port` in the `[heartbeat]` section of your config file, the Docker image includes a built-in `HEALTHCHECK` that queries the health server on port 6001. To use a different port, override the healthcheck in your Docker Compose file:
+
+```yaml
+healthcheck:
+  test: ["/usr/bin/purpleair2mqtt", "-healthcheck", "-healthcheck-url", "http://localhost:YOUR_PORT"]
+  interval: 60s
+  timeout: 5s
+  retries: 3
 ```
 
 ### Building the Container Locally

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ services:
 
 ### Docker Health Check
 
-If you configure `health_port` in the `[heartbeat]` section of your config file, the Docker image includes a built-in `HEALTHCHECK` that queries the health server on port 6001. To use a different port, override the healthcheck in your Docker Compose file:
+If you configure `health_port` in the `[heartbeat]` section of your config file, the Docker image includes a built-in `HEALTHCHECK` that queries the health server at `http://localhost:6001`. To use a different port, override the healthcheck in your Docker Compose file:
 
 ```yaml
 healthcheck:
@@ -201,6 +201,13 @@ healthcheck:
   interval: 60s
   timeout: 5s
   retries: 3
+```
+
+If you don't configure `health_port`, the built-in `HEALTHCHECK` will report the container as unhealthy. In that case, disable it in your Compose file:
+
+```yaml
+healthcheck:
+  disable: true
 ```
 
 ### Building the Container Locally

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,3 +41,16 @@
 #     password = "your_password"
 #     measurement_name = "purpleair_monitor"
 #     status_measurement_name = "purpleair_status"
+
+# Heartbeat integration (optional)
+# Sends a heartbeat ping and/or serves a health check endpoint after each
+# successful poll cycle. Works well with Uptime Kuma push monitors.
+# [heartbeat]
+#     # URL to GET for heartbeat pings (e.g. Uptime Kuma push URL)
+#     url = "https://uptimekuma.example.com:9001/api/push/abcd1234?status=up&msg=OK&ping="
+#     # Heartbeat ping interval in seconds (default: poll_rate)
+#     interval_s = 120
+#     # Liveness threshold in seconds (default: poll_rate * 3)
+#     threshold_s = 360
+#     # Port for the health check HTTP server (useful as a Docker HEALTHCHECK)
+#     health_port = 6001

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -6,3 +6,10 @@ services:
     network_mode: host
     volumes:
       - ./config.toml:/config.toml:ro
+    # If heartbeat health_port is configured in config.toml, Docker can
+    # use the built-in healthcheck. Override the default URL/port if needed:
+    # healthcheck:
+    #   test: ["/usr/bin/purpleair2mqtt", "-healthcheck", "-healthcheck-url", "http://localhost:6001"]
+    #   interval: 60s
+    #   timeout: 5s
+    #   retries: 3

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -6,8 +6,8 @@ services:
     network_mode: host
     volumes:
       - ./config.toml:/config.toml:ro
-    # If heartbeat health_port is configured in config.toml, Docker can
-    # use the built-in healthcheck. Override the default URL/port if needed:
+    # If heartbeat health_port is configured in config.toml, you can enable
+    # a Docker healthcheck using curl (included in the image):
     # healthcheck:
     #   test: ["curl", "-sf", "http://localhost:6001/"]
     #   interval: 60s

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -9,7 +9,7 @@ services:
     # If heartbeat health_port is configured in config.toml, Docker can
     # use the built-in healthcheck. Override the default URL/port if needed:
     # healthcheck:
-    #   test: ["/usr/bin/purpleair2mqtt", "-healthcheck", "-healthcheck-url", "http://localhost:6001"]
+    #   test: ["curl", "-sf", "http://localhost:6001/"]
     #   interval: 60s
     #   timeout: 5s
     #   retries: 3

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/avast/retry-go/v4 v4.6.1
+	github.com/cdzombak/heartbeat v1.1.2
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c
 	github.com/naoina/toml v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
 github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
+github.com/cdzombak/heartbeat v1.1.2 h1:JPVO7h7m+UzxOZS173ygXouM+jcjIXJxGRvTKbn1QOg=
+github.com/cdzombak/heartbeat v1.1.2/go.mod h1:pK5GKvyesTKeHFpI4PeJSElTO0m0TqjG/r9PG81yyGA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2ISgCl2W7nE=

--- a/purpleair2mqtt.go
+++ b/purpleair2mqtt.go
@@ -296,6 +296,9 @@ func main() {
 	}
 
 	var hb heartbeat.Heartbeat
+	if config.Heartbeat != (tomlConfigHeartbeat{}) && config.Heartbeat.URL == "" && config.Heartbeat.HealthPort == 0 {
+		logger.Fatal("[heartbeat] section requires at least one of url or health_port to be set")
+	}
 	if config.Heartbeat.URL != "" || config.Heartbeat.HealthPort != 0 {
 		thresholdS := config.Heartbeat.ThresholdS
 		if thresholdS == 0 {
@@ -332,7 +335,9 @@ func main() {
 		pastatus := new(purpleAirStatus)
 		// see: https://stackoverflow.com/a/31129967/57626
 		if err := getJson(config.PurpleAir.Url, pastatus, myClient); err != nil {
-			panic(err)
+			logger.Errorf("PurpleAir poll failed: %s", err)
+			time.Sleep(time.Duration(config.PurpleAir.PollRate) * time.Second)
+			continue
 		}
 		normalizePaStatus(pastatus)
 		calculateEPAAQI(pastatus)

--- a/purpleair2mqtt.go
+++ b/purpleair2mqtt.go
@@ -614,7 +614,9 @@ func publishMQTT(status *purpleAirStatus) error {
 		logger.Infof("field[%s] = [%v]", fieldName, fieldValue)
 		logger.Infof("topic = %s", topic)
 		token := client.Publish(topic, 0, false, fmt.Sprintf("%v", fieldValue))
-		token.Wait()
+		if !token.WaitTimeout(10 * time.Second) {
+			return fmt.Errorf("timeout publishing to MQTT topic %s", topic)
+		}
 		if err := token.Error(); err != nil {
 			return fmt.Errorf("error publishing to MQTT topic %s: %w", topic, err)
 		}
@@ -635,7 +637,9 @@ func publishSensorEPAAQI(monitor *purpleAirMonitor, sensor string) error {
 
 	publish := func(topic string, payload string) error {
 		token := client.Publish(topic, 0, false, payload)
-		token.Wait()
+		if !token.WaitTimeout(10 * time.Second) {
+			return fmt.Errorf("timeout publishing to MQTT topic %s", topic)
+		}
 		if err := token.Error(); err != nil {
 			return fmt.Errorf("error publishing to MQTT topic %s: %w", topic, err)
 		}

--- a/purpleair2mqtt.go
+++ b/purpleair2mqtt.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/cdzombak/heartbeat"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/naoina/toml"
 	"github.com/withmandala/go-log"
@@ -56,11 +57,19 @@ type tomlConfigPurpleAir struct {
 	Timeout  int // Timeout in seconds for HTTP requests
 }
 
+type tomlConfigHeartbeat struct {
+	URL        string // URL to GET for heartbeat pings
+	IntervalS  int    // Heartbeat interval in seconds
+	ThresholdS int    // Liveness threshold in seconds
+	HealthPort int    // Port for the health check HTTP server
+}
+
 type tomlConfig struct {
 	PurpleAir tomlConfigPurpleAir
 	Mqtt      tomlConfigMQTT
 	Hass      tomlConfigHass
 	Influx    tomlConfigInflux
+	Heartbeat tomlConfigHeartbeat
 }
 
 type purpleAirMonitor struct {
@@ -223,11 +232,28 @@ func main() {
 
 	configFile := flag.String("config", "", "Filename with configuration")
 	printVersion := flag.Bool("version", false, "Print version and exit")
+	healthcheck := flag.Bool("healthcheck", false, "Run a health check against the local health server and exit")
+	healthcheckURL := flag.String("healthcheck-url", "http://localhost:6001", "URL for the health check endpoint")
 	flag.Parse()
 
 	if *printVersion {
 		fmt.Println(version)
 		os.Exit(0)
+	}
+
+	if *healthcheck {
+		hcClient := &http.Client{Timeout: 5 * time.Second}
+		resp, err := hcClient.Get(*healthcheckURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "healthcheck failed: %s\n", err)
+			os.Exit(1)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusOK {
+			os.Exit(0)
+		}
+		fmt.Fprintf(os.Stderr, "healthcheck failed: HTTP %d\n", resp.StatusCode)
+		os.Exit(1)
 	}
 
 	if *configFile != "" {
@@ -269,6 +295,32 @@ func main() {
 		}
 	}
 
+	var hb heartbeat.Heartbeat
+	if config.Heartbeat.URL != "" || config.Heartbeat.HealthPort != 0 {
+		thresholdS := config.Heartbeat.ThresholdS
+		if thresholdS == 0 {
+			thresholdS = config.PurpleAir.PollRate * 3
+		}
+		intervalS := config.Heartbeat.IntervalS
+		if intervalS == 0 {
+			intervalS = config.PurpleAir.PollRate
+		}
+		var err error
+		hb, err = heartbeat.NewHeartbeat(&heartbeat.Config{
+			HeartbeatInterval: time.Duration(intervalS) * time.Second,
+			LivenessThreshold: time.Duration(thresholdS) * time.Second,
+			HeartbeatURL:      config.Heartbeat.URL,
+			Port:              config.Heartbeat.HealthPort,
+			OnError: func(err error) {
+				logger.Errorf("heartbeat error: %s", err)
+			},
+		})
+		if err != nil {
+			logger.Fatalf("failed to create heartbeat: %s", err)
+		}
+		hb.Start()
+	}
+
 	logger.Infof("HTTP Target: %s", config.PurpleAir.Url)
 	timeout := 15
 	if config.PurpleAir.Timeout > 0 {
@@ -299,8 +351,13 @@ func main() {
 		logger.Infof("US EPA AQI: %d (%s - %s)", pastatus.EPAAQI, pastatus.EPAAQICategory, pastatus.EPAAQIColor)
 		logger.Infof("US EPA PM2.5 AQI: %d, PM10 AQI: %d", pastatus.EPAPM25AQI, pastatus.EPAPM10AQI)
 
+		pollOK := true
+
 		if config.Influx != (tomlConfigInflux{}) {
-			write_influx(pastatus, &pastatus.A, &pastatus.B)
+			if err := writeInflux(pastatus, &pastatus.A, &pastatus.B); err != nil {
+				logger.Errorf("InfluxDB write failed: %s", err)
+				pollOK = false
+			}
 		}
 
 		if config.Mqtt != (tomlConfigMQTT{}) {
@@ -308,6 +365,10 @@ func main() {
 				config.Mqtt.Topic = pastatus.Geo
 			}
 			publishMQTT(pastatus)
+		}
+
+		if pollOK && hb != nil {
+			hb.Alive(time.Now())
 		}
 
 		logger.Debugf("Sleeping for %d seconds", config.PurpleAir.PollRate)
@@ -505,12 +566,12 @@ func monitor_to_point(monitor *purpleAirMonitor) (*influxclient.Point, error) {
 	return influxclient.NewPoint(measurementName, tags, values, time.Now())
 }
 
-func write_influx(status *purpleAirStatus, monitorA *purpleAirMonitor, monitorB *purpleAirMonitor) {
+func writeInflux(status *purpleAirStatus, monitorA *purpleAirMonitor, monitorB *purpleAirMonitor) error {
 	c, err := influxclient.NewHTTPClient(influxclient.HTTPConfig{
 		Addr: fmt.Sprintf("http://%s:%d", config.Influx.Hostname, config.Influx.Port),
 	})
 	if err != nil {
-		logger.Errorf("Error creating InfluxDB Client: %s", err.Error())
+		return fmt.Errorf("error creating InfluxDB Client: %w", err)
 	}
 	defer func() { _ = c.Close() }()
 
@@ -519,32 +580,31 @@ func write_influx(status *purpleAirStatus, monitorA *purpleAirMonitor, monitorB 
 		Precision: "s",
 	})
 	if err != nil {
-		logger.Errorf("error creating batchpoints: %s", err)
+		return fmt.Errorf("error creating batchpoints: %w", err)
 	}
 
 	pointA, err := monitor_to_point(monitorA)
 	if err != nil {
-		logger.Errorf("error translating monitor sample to point")
+		return fmt.Errorf("error translating monitor sample to point: %w", err)
 	}
 	bp.AddPoint(pointA)
 
 	pointB, err := monitor_to_point(monitorB)
 	if err != nil {
-		logger.Errorf("error translating monitor sample to point")
+		return fmt.Errorf("error translating monitor sample to point: %w", err)
 	}
 	bp.AddPoint(pointB)
 
 	pointS, err := status_to_point(status)
 	if err != nil {
-		logger.Errorf("error translating status to point")
+		return fmt.Errorf("error translating status to point: %w", err)
 	}
 	bp.AddPoint(pointS)
 
-	err = c.Write(bp)
-
-	if err != nil {
-		logger.Fatal(err)
+	if err = c.Write(bp); err != nil {
+		return fmt.Errorf("error writing to InfluxDB: %w", err)
 	}
+	return nil
 }
 
 func publishMQTT(status *purpleAirStatus) {

--- a/purpleair2mqtt.go
+++ b/purpleair2mqtt.go
@@ -232,28 +232,11 @@ func main() {
 
 	configFile := flag.String("config", "", "Filename with configuration")
 	printVersion := flag.Bool("version", false, "Print version and exit")
-	healthcheck := flag.Bool("healthcheck", false, "Run a health check against the local health server and exit")
-	healthcheckURL := flag.String("healthcheck-url", "http://localhost:6001", "URL for the health check endpoint")
 	flag.Parse()
 
 	if *printVersion {
 		fmt.Println(version)
 		os.Exit(0)
-	}
-
-	if *healthcheck {
-		hcClient := &http.Client{Timeout: 5 * time.Second}
-		resp, err := hcClient.Get(*healthcheckURL)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "healthcheck failed: %s\n", err)
-			os.Exit(1)
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode == http.StatusOK {
-			os.Exit(0)
-		}
-		fmt.Fprintf(os.Stderr, "healthcheck failed: HTTP %d\n", resp.StatusCode)
-		os.Exit(1)
 	}
 
 	if *configFile != "" {

--- a/purpleair2mqtt.go
+++ b/purpleair2mqtt.go
@@ -364,7 +364,10 @@ func main() {
 			if config.Mqtt.Topic == "" {
 				config.Mqtt.Topic = pastatus.Geo
 			}
-			publishMQTT(pastatus)
+			if err := publishMQTT(pastatus); err != nil {
+				logger.Errorf("MQTT publish failed: %s", err)
+				pollOK = false
+			}
 		}
 
 		if pollOK && hb != nil {
@@ -607,7 +610,7 @@ func writeInflux(status *purpleAirStatus, monitorA *purpleAirMonitor, monitorB *
 	return nil
 }
 
-func publishMQTT(status *purpleAirStatus) {
+func publishMQTT(status *purpleAirStatus) error {
 	v := reflect.ValueOf(*status)
 	typeOfStatus := v.Type()
 
@@ -624,31 +627,47 @@ func publishMQTT(status *purpleAirStatus) {
 		logger.Infof("topic = %s", topic)
 		token := client.Publish(topic, 0, false, fmt.Sprintf("%v", fieldValue))
 		token.Wait()
+		if err := token.Error(); err != nil {
+			return fmt.Errorf("error publishing to MQTT topic %s: %w", topic, err)
+		}
 	}
 
 	// Also publish sensor A and B EPA AQI values
-	publishSensorEPAAQI(&status.A, "A")
-	publishSensorEPAAQI(&status.B, "B")
+	if err := publishSensorEPAAQI(&status.A, "A"); err != nil {
+		return err
+	}
+	if err := publishSensorEPAAQI(&status.B, "B"); err != nil {
+		return err
+	}
+	return nil
 }
 
-func publishSensorEPAAQI(monitor *purpleAirMonitor, sensor string) {
+func publishSensorEPAAQI(monitor *purpleAirMonitor, sensor string) error {
 	baseTopic := fmt.Sprintf("%s/%s/sensor_%s", config.Mqtt.TopicPrefix, config.Mqtt.Topic, sensor)
 
-	token := client.Publish(fmt.Sprintf("%s/epa_aqi", baseTopic), 0, false, fmt.Sprintf("%d", monitor.EPAAQI))
-	token.Wait()
+	publish := func(topic string, payload string) error {
+		token := client.Publish(topic, 0, false, payload)
+		token.Wait()
+		if err := token.Error(); err != nil {
+			return fmt.Errorf("error publishing to MQTT topic %s: %w", topic, err)
+		}
+		return nil
+	}
 
-	token = client.Publish(fmt.Sprintf("%s/epa_pm25_aqi", baseTopic), 0, false, fmt.Sprintf("%d", monitor.EPAPM25AQI))
-	token.Wait()
-
-	token = client.Publish(fmt.Sprintf("%s/epa_pm10_aqi", baseTopic), 0, false, fmt.Sprintf("%d", monitor.EPAPM10AQI))
-	token.Wait()
-
-	token = client.Publish(fmt.Sprintf("%s/epa_aqi_category", baseTopic), 0, false, monitor.EPAAQICategory)
-	token.Wait()
-
-	token = client.Publish(fmt.Sprintf("%s/epa_aqi_color", baseTopic), 0, false, monitor.EPAAQIColor)
-	token.Wait()
-
-	token = client.Publish(fmt.Sprintf("%s/epa_aqi_color_rgb", baseTopic), 0, false, monitor.EPAAQIColorRGB)
-	token.Wait()
+	if err := publish(fmt.Sprintf("%s/epa_aqi", baseTopic), fmt.Sprintf("%d", monitor.EPAAQI)); err != nil {
+		return err
+	}
+	if err := publish(fmt.Sprintf("%s/epa_pm25_aqi", baseTopic), fmt.Sprintf("%d", monitor.EPAPM25AQI)); err != nil {
+		return err
+	}
+	if err := publish(fmt.Sprintf("%s/epa_pm10_aqi", baseTopic), fmt.Sprintf("%d", monitor.EPAPM10AQI)); err != nil {
+		return err
+	}
+	if err := publish(fmt.Sprintf("%s/epa_aqi_category", baseTopic), monitor.EPAAQICategory); err != nil {
+		return err
+	}
+	if err := publish(fmt.Sprintf("%s/epa_aqi_color", baseTopic), monitor.EPAAQIColor); err != nil {
+		return err
+	}
+	return publish(fmt.Sprintf("%s/epa_aqi_color_rgb", baseTopic), monitor.EPAAQIColorRGB)
 }


### PR DESCRIPTION
## Summary

Integrates [`github.com/cdzombak/heartbeat`](https://github.com/cdzombak/heartbeat) to provide health monitoring:

- **Outgoing heartbeat pings** (e.g. to Uptime Kuma push monitors) via configurable URL
- **Local HTTP health server** for use as a Docker healthcheck or external monitoring

The heartbeat `Alive()` is called after each successful poll cycle. If polling PurpleAir, writing to InfluxDB, or publishing to MQTT fails, the heartbeat is skipped for that cycle.

Configuration is via a new `[heartbeat]` TOML section with `url`, `interval_s`, `threshold_s`, and `health_port` fields—all optional, matching the existing config conventions. The `[heartbeat]` section is validated at startup: if present, at least one of `url` or `health_port` must be set.

### Docker image changes

- **Base image changed from `scratch` to `alpine:latest`** with `curl` installed, so users can configure a `curl`-based Docker healthcheck in their Compose file.
- **No `HEALTHCHECK` instruction in the Dockerfile** — users opt in by adding a healthcheck to their Compose config. This avoids breaking existing deployments that don't configure `health_port`.

### Error handling refactors

- `write_influx` → `writeInflux`: now returns errors instead of calling `logger.Fatal`, so InfluxDB failures no longer crash the process.
- `publishMQTT` / `publishSensorEPAAQI`: now return errors, and use `token.WaitTimeout(10*time.Second)` instead of blocking `token.Wait()` to avoid hanging indefinitely on unresponsive brokers.
- `getJson` (PurpleAir poll): failures now log and `continue` the loop instead of panicking, so transient sensor outages leave the heartbeat stale rather than crashing the process.

## Review & Testing Checklist for Human

- [ ] **Error handling behavioral changes**: Three functions changed from fatal/panic to log-and-continue. InfluxDB write failures used to crash the process (`logger.Fatal`); PurpleAir poll failures used to `panic`. Both now log the error and continue the polling loop. Verify this is the desired resilience behavior vs. the previous crash-and-restart approach (e.g. a supervisor restarting on crash may have been preferable in some failure modes).
- [ ] **MQTT publish timeout (10s)**: `token.WaitTimeout(10 * time.Second)` replaces `token.Wait()`. If the MQTT broker is slow but recoverable, this will treat it as a failure and skip the heartbeat. Verify 10 seconds is an appropriate timeout for your deployment.
- [ ] **MQTT error detection coverage**: `token.Error()` is checked after `WaitTimeout`, but only catches errors reported by the paho MQTT client. If the broker is unreachable at connection time (handled separately at startup), or if publishes silently fail, the heartbeat may still fire. Verify this provides adequate coverage for your MQTT failure scenarios.
- [ ] **Alpine base image**: The Docker image changed from `scratch` to `alpine:latest`. This increases image size and attack surface but is required for `curl`. Verify this trade-off is acceptable.
- [ ] **Test plan**: Deploy with a test config that includes `[heartbeat]` with `health_port = 6001`, verify `curl http://localhost:6001/` returns `{"ok":true}` after a successful poll and `{"ok":false}` / HTTP 503 when the sensor is unreachable. Test config validation by setting `[heartbeat]` with only `interval_s` (no `url` or `health_port`) and confirm it exits with an error.

### Notes

- Default `interval_s` falls back to `poll_rate`; default `threshold_s` falls back to `poll_rate * 3`.
- No new automated tests were added; the existing test suite covers only AQI calculations.

Link to Devin session: https://app.devin.ai/sessions/0291b5111dfc4537bf7dccd7bb683029
Requested by: @cdzombak